### PR TITLE
Render ERB in database.yml so vmt restore resolves the target database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.0
+
+* **`vmt restore` now reads Rails `database.yml` files that use ERB.** Database names written as `<%= ENV.fetch("PGDATABASE") { "myapp-dev" } %>` previously caused a confusing "Couldn't connect to the target database" failure, because vmt fed the raw template text to Postgres as the database name. vmt now renders the env-reading expressions these files use — `<%= ENV["X"] %>`, `<%= ENV.fetch("X") { "default" } %>`, `<%= ENV.fetch("X", "default") %>`, and the `<%= ENV["X"] || "default" %>` fallback form — honouring environment variables and their defaults exactly as Rails does, before parsing the YAML. Any output tag it can't evaluate (e.g. `<%= Rails.application.credentials… %>`) is left untouched and reported with a warning, so an unsupported construct surfaces clearly instead of as a cryptic connection error. Config files without ERB (non-Ruby projects) are unaffected, and there's no new runtime dependency. Pass `--database` to override the file as before.
+
 # v2.0.1
 
 * **CI release pipeline now produces downloadable binaries again.** The previous releases (v1.4.3, v1.5.0, v2.0.0) had their tags pushed but the release workflow failed before it could attach any artifacts, so their GitHub release pages are empty. This release is functionally identical to v2.0.0 — install it to get the v2.0.0 features with working install scripts.

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -82,7 +82,7 @@ func Run(log *util.Logger, port string, host string, sourceShard string, b2id st
 		return err
 	}
 
-	target, err := util.GetDatabaseConfig(databaseSelection.Database, "custom", sourceShard, response.User, "", host, port, configFile)
+	target, err := util.GetDatabaseConfig(log, databaseSelection.Database, "custom", sourceShard, response.User, "", host, port, configFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -117,7 +117,7 @@ func Run(log *util.Logger, targetEnvironment string, targetShard string, b2id st
 
 	selectedBackup := displayToBackup[backupSelection.Backup]
 
-	target, err := util.GetDatabaseConfig(targetDatabase, targetEnvironment, targetShard, targetUsername, targetPassword, targetHost, targetPort, configFile)
+	target, err := util.GetDatabaseConfig(log, targetDatabase, targetEnvironment, targetShard, targetUsername, targetPassword, targetHost, targetPort, configFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/dbconf.go
+++ b/pkg/util/dbconf.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ type ShardedDatabaseConfig struct {
 }
 
 // GetDatabaseConfig based on provided arguments
-func GetDatabaseConfig(database string, environment string, shard string, user string, password string, host string, port string, configFile string) (TargetConfig, error) {
+func GetDatabaseConfig(log *Logger, database string, environment string, shard string, user string, password string, host string, port string, configFile string) (TargetConfig, error) {
 	target := TargetConfig{}
 	if database == "" {
 		yamlFile, err := ioutil.ReadFile(configFile)
@@ -42,9 +43,17 @@ func GetDatabaseConfig(database string, environment string, shard string, user s
 			return target, err
 		}
 
+		// database.yml is an ERB template in Rails projects; render it so values
+		// like `<%= ENV.fetch("PGDATABASE") { "myapp-dev" } %>` resolve before parsing.
+		renderedStr, unresolved := renderERB(string(yamlFile))
+		rendered := []byte(renderedStr)
+		for _, tag := range unresolved {
+			log.Warn(fmt.Sprintf("Could not evaluate ERB in %s: %s — leaving it unrendered (only ENV[...] and ENV.fetch(...) are supported)", configFile, tag))
+		}
+
 		if shard != "" {
 			dbConfig := ShardedDatabaseConfig{}
-			err = yaml.Unmarshal(yamlFile, &dbConfig)
+			err = yaml.Unmarshal(rendered, &dbConfig)
 			if err != nil {
 				return target, err
 			}
@@ -68,7 +77,7 @@ func GetDatabaseConfig(database string, environment string, shard string, user s
 			}
 		} else {
 			dbConfig := DatabaseConfig{}
-			err = yaml.Unmarshal(yamlFile, &dbConfig)
+			err = yaml.Unmarshal(rendered, &dbConfig)
 			if err != nil {
 				return target, err
 			}

--- a/pkg/util/erb.go
+++ b/pkg/util/erb.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Rails database.yml files are ERB templates: values like the database name are
+// commonly written as `<%= ENV.fetch("PGDATABASE") { "myapp-dev" } %>`. Rails
+// renders these before parsing the YAML; a plain YAML parser sees the raw tag
+// instead and tries to connect to a database literally named `<%= ... %>`.
+//
+// vmt has no Ruby runtime to lean on, so renderERB evaluates the small subset of
+// ERB that database.yml files actually use: reading environment variables, with
+// an optional default. Files without ERB tags (e.g. non-Ruby projects) pass
+// through untouched.
+
+// erbOutputRe matches an ERB output tag `<%= expr %>`, tolerating the
+// whitespace-trim markers Rails permits (`<%=- ... -%>`).
+var erbOutputRe = regexp.MustCompile(`(?s)<%=-?\s*(.*?)\s*-?%>`)
+
+// erbOtherRe matches non-output tags — comments `<%# ... %>` and bare code
+// `<% ... %>` — which produce no output in Rails and are stripped here.
+var erbOtherRe = regexp.MustCompile(`(?s)<%[^=].*?%>|<%%>`)
+
+// envFetchRe matches `ENV.fetch("NAME")` with an optional default supplied
+// either as a second argument (`, "default"`) or a block (`{ "default" }`).
+var envFetchRe = regexp.MustCompile(`^ENV\.fetch\(\s*['"]([^'"]+)['"]\s*(?:,\s*(.+?)\s*)?\)\s*(?:\{\s*(.+?)\s*\})?$`)
+
+// envIndexRe matches `ENV["NAME"]`, optionally with a `|| "default"` fallback —
+// `<%= ENV["DB_HOST"] || "localhost" %>` is as common as the fetch form.
+var envIndexRe = regexp.MustCompile(`^ENV\[\s*['"]([^'"]+)['"]\s*\]\s*(?:\|\|\s*(.+?)\s*)?$`)
+
+// renderERB evaluates the ENV-reading ERB expressions in a database.yml file and
+// returns the rendered YAML alongside any output tags it could not evaluate. An
+// unrecognised tag is left verbatim, but since that verbatim text is itself valid
+// YAML it would not fail at parse time — it would silently become the value and
+// resurface later as an opaque connection error. The caller is expected to warn
+// about the returned tags so the limitation is visible.
+func renderERB(content string) (string, []string) {
+	var unresolved []string
+
+	out := erbOutputRe.ReplaceAllStringFunc(content, func(tag string) string {
+		expr := erbOutputRe.FindStringSubmatch(tag)[1]
+		if value, ok := evalEnvExpr(expr); ok {
+			return value
+		}
+		unresolved = append(unresolved, tag)
+		return tag
+	})
+
+	return erbOtherRe.ReplaceAllString(out, ""), unresolved
+}
+
+// evalEnvExpr evaluates a single ERB expression. The bool result reports whether
+// the expression was recognised; an unrecognised expression is left untouched.
+func evalEnvExpr(expr string) (string, bool) {
+	if m := envIndexRe.FindStringSubmatch(expr); m != nil {
+		if value, ok := os.LookupEnv(m[1]); ok {
+			return value, true
+		}
+		// Key absent: Ruby's `ENV["X"]` is nil, so `|| default` applies. When
+		// there's no fallback, m[2] is empty and unquote yields "".
+		return unquote(m[2]), true
+	}
+
+	if m := envFetchRe.FindStringSubmatch(expr); m != nil {
+		if value, ok := os.LookupEnv(m[1]); ok {
+			return value, true
+		}
+		if m[3] != "" { // block default: ENV.fetch("X") { "default" }
+			return unquote(m[3]), true
+		}
+		if m[2] != "" { // argument default: ENV.fetch("X", "default")
+			return unquote(m[2]), true
+		}
+		return "", true
+	}
+
+	return "", false
+}
+
+// unquote strips a single matched pair of surrounding quotes, leaving bare
+// literals (numbers, booleans) as-is. Ruby's `""` default becomes an empty string.
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/pkg/util/erb_test.go
+++ b/pkg/util/erb_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderERB(t *testing.T) {
+	t.Setenv("PGDATABASE", "noticehub-app-dev")
+	t.Setenv("PGHOST", "db.internal")
+	// PGUSER and PGPASSWORD are intentionally left unset to exercise defaults.
+
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"fetch with block default, env set", `<%= ENV.fetch("PGDATABASE") { "fallback" } %>`, "noticehub-app-dev"},
+		{"fetch with block default, env unset", `<%= ENV.fetch("PGUSER") { "localhost" } %>`, "localhost"},
+		{"fetch with empty block default", `<%= ENV.fetch("PGPASSWORD") { "" } %>`, ""},
+		{"fetch with bare integer default", `<%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>`, "10"},
+		{"fetch with argument default", `<%= ENV.fetch("PGUSER", "postgres") %>`, "postgres"},
+		{"fetch without default, env unset", `<%= ENV.fetch("PGUSER") %>`, ""},
+		{"index, env set", `<%= ENV["PGHOST"] %>`, "db.internal"},
+		{"index, env unset", `<%= ENV["MISSING"] %>`, ""},
+		{"index with || fallback, env set", `<%= ENV["PGHOST"] || "localhost" %>`, "db.internal"},
+		{"index with || fallback, env unset", `<%= ENV["MISSING"] || "localhost" %>`, "localhost"},
+		{"index with || fallback, single quotes", `<%= ENV['MISSING'] || 'fallback' %>`, "fallback"},
+		{"single quotes", `<%= ENV.fetch('PGHOST') { 'x' } %>`, "db.internal"},
+		{"trim markers", `<%=- ENV.fetch("PGHOST") { "x" } -%>`, "db.internal"},
+		{"comment tag stripped", `before<%# secret %>after`, "beforeafter"},
+		{"no erb passes through", "database: plain-name", "database: plain-name"},
+		{"unrecognised expr left verbatim", `<%= Rails.env %>`, `<%= Rails.env %>`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _ := renderERB(tc.in)
+			assert.Equal(t, tc.out, out)
+		})
+	}
+}
+
+func TestRenderERBReportsUnresolved(t *testing.T) {
+	t.Setenv("PGHOST", "db.internal")
+
+	out, unresolved := renderERB(`a: <%= ENV["PGHOST"] %>
+b: <%= Rails.application.credentials.dig(:db) %>
+c: <%= ENV["MISSING"] || "ok" %>`)
+
+	assert.Equal(t, "a: db.internal\nb: <%= Rails.application.credentials.dig(:db) %>\nc: ok", out)
+	assert.Equal(t, []string{`<%= Rails.application.credentials.dig(:db) %>`}, unresolved)
+}
+
+func TestRenderERBFullConfig(t *testing.T) {
+	t.Setenv("PGDATABASE", "noticehub-app-dev")
+
+	in := `development:
+  host: "localhost"
+  database: <%= ENV.fetch("PGDATABASE") { "noticehub-app-dev" } %>
+  username: <%= ENV.fetch("PGUSER") { "" } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
+`
+	out := "development:\n" +
+		"  host: \"localhost\"\n" +
+		"  database: noticehub-app-dev\n" +
+		"  username: \n" + // empty value leaves the trailing space; YAML reads it as nil
+		"  pool: 10\n"
+	rendered, _ := renderERB(in)
+	assert.Equal(t, out, rendered)
+}


### PR DESCRIPTION
## Problem

`vmt restore` parsed `database.yml` as plain YAML, so a Rails database name written as `<%= ENV.fetch("PGDATABASE") { "myapp-dev" } %>` was handed to Postgres verbatim. The restore then failed with a confusing "Couldn't connect to the target database" — the tool was trying to connect to a database literally named `<%= ... %>`. Rails resolves the ERB; a Go YAML parser does not.

## Change

Evaluate the env-reading ERB these files actually use, before parsing the YAML:

- `<%= ENV["X"] %>`
- `<%= ENV.fetch("X") { "default" } %>`
- `<%= ENV.fetch("X", "default") %>`
- `<%= ENV["X"] || "default" %>` (common fallback form)

Environment variables and their defaults are honoured exactly as Rails does (a default applies only when the key is **absent**, not when it's empty). Output tags that aren't recognised (e.g. `<%= Rails.application.credentials… %>`) are left untouched and reported with a warning, so an unsupported construct surfaces clearly instead of as a cryptic connection error later.

- Config files without ERB (non-Ruby projects) are unaffected.
- No new runtime dependency — pure Go, no `ruby` required.
- `--database` still overrides the file as before.

## Testing

- `go test ./pkg/...` (new `pkg/util/erb_test.go` covers each pattern, the `||` fallback, unresolved-tag reporting, and a full-config render).
- `go vet ./...` clean.
- Verified end-to-end against a real `database.yml`: `database` resolves to `myapp-dev`, and an unsupported tag emits a stderr warning.